### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,7 @@ Distributed tracing helps teams keep track of requests between microservices. Mi
 // =================================================================================================
 
 == What you'll learn
+
 The complexity of microservices architecture can make it more difficult to understand how services depend on or affect each other and to identify sources of latency or inaccuracies.
 
 One way to increase the observability of an application is by emitting traces. https://opentelemetry.io/[OpenTelemetry^] is a set of APIs, SDKs, tooling, and integrations designed to create and manage telemetry data such as traces, metrics, and logs. MicroProfile Telemetry adopts OpenTelemetry so your Java applications can benefit from both manual and automatic traces.


### PR DESCRIPTION
fix that cloud-hosted guide does not show the **What you’ll learn** section correctly